### PR TITLE
Added publish workflow and release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: 'v$RESOLVED_VERSION ✨'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+
+name: "Publish and create releases"
+on:
+  pull_request:
+    branches:
+      - master
+    types: [closed]
+jobs:
+  release:
+    name: "Release"
+    runs-on: macos-latest
+    if: ${{ github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.2.0
+      - name: node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - run: yarn install
+      - run: yarn webpack-build
+      - run: yarn config set version-tag-prefix "v"
+      - run: git config core.hooksPath /dev/null
+
+      - name: Bump version and create tag
+        if: contains(github.event.pull_request.labels.*.name, 'release')
+        run: yarn version --patch
+
+      - name: Bump version
+        if: "!contains(github.event.pull_request.labels.*.name, 'release')"
+        run: yarn version --patch --no-git-tag-version
+
+      - uses: EndBug/add-and-commit@v7
+        with:
+          branch: master
+          message: 'New version release'
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read package.json
+        uses: tyankatsu0105/read-package-version-actions@v1
+        id: package-version
+
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v5.15.0
+        if: ${{contains(github.event.pull_request.labels.*.name, 'release')}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: v${{ steps.package-version.outputs.version }}
+          publish: true
+      - name: "Publish"
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          access: "public"
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,25 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# production
+/build
+/lib
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.husky
+.github
+.editorconfig
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+#example
+/example


### PR DESCRIPTION
Fixes #40 

- PRs with the label `release` will trigger the create the release notes
- PRs with the label `skip-ci` will skip the publish and release action
- Every PR merge into master will trigger the version bump (patch by default) and npm publish