### PR TITLE
Fixed UI issues in editor

### DIFF
--- a/lib/components/Editor/CustomExtensions/BubbleMenu/index.js
+++ b/lib/components/Editor/CustomExtensions/BubbleMenu/index.js
@@ -64,7 +64,11 @@ export default function index({ editor, formatterOptions }) {
   return (
     <BubbleMenu
       editor={editor}
-      tippyOptions={{ arrow: roundArrow }}
+      tippyOptions={{
+        arrow: roundArrow,
+        placement: "top-start",
+        zIndex: 99998,
+      }}
       className="relative flex overflow-hidden rounded shadow editor-command-list--root"
     >
       {options

--- a/lib/components/Editor/CustomExtensions/BubbleMenu/index.js
+++ b/lib/components/Editor/CustomExtensions/BubbleMenu/index.js
@@ -4,6 +4,7 @@ import { BubbleMenu } from "@tiptap/react";
 import {
   TextBold,
   TextItalic,
+  Underline,
   TextCross,
   Link,
   Code,
@@ -28,6 +29,12 @@ export default function index({ editor, formatterOptions }) {
       command: () => editor.chain().focus().toggleItalic().run(),
       active: editor.isActive("italic"),
       optionName: "italic",
+    },
+    {
+      Icon: Underline,
+      command: () => editor.chain().focus().toggleUnderline().run(),
+      active: editor.isActive("underline"),
+      optionName: "underline",
     },
     {
       Icon: TextCross,

--- a/lib/components/Editor/CustomExtensions/FixedMenu/index.js
+++ b/lib/components/Editor/CustomExtensions/FixedMenu/index.js
@@ -4,6 +4,7 @@ import {
   TextItalic,
   Underline,
   TextCross,
+  Highlight,
   Code,
   ListDot,
   ListNumber,
@@ -50,6 +51,12 @@ const FixedMenu = ({ editor, variables, setImageUploadVisible }) => {
       command: () => editor.chain().focus().toggleStrike().run(),
       active: editor.isActive("strike"),
       optionName: "strike",
+    },
+    {
+      Icon: Highlight,
+      command: () => editor.chain().focus().toggleHighlight().run(),
+      active: editor.isActive("highlight"),
+      optionName: "highlight",
     },
   ];
 

--- a/lib/components/Editor/CustomExtensions/SlashCommands/CommandsList.js
+++ b/lib/components/Editor/CustomExtensions/SlashCommands/CommandsList.js
@@ -66,7 +66,7 @@ class CommandsList extends React.Component {
 
   render() {
     return (
-      <div className="relative p-3 space-y-2 overflow-hidden rounded shadow editor-command-list--root">
+      <div className="relative p-3 -mr-1 space-y-2 overflow-x-hidden overflow-y-scroll rounded shadow h-80 editor-command-list--root">
         {this.props.items.map((item, index) => (
           <Item
             key={item.title}

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -15,6 +15,7 @@ const Tiptap = (
     formatterOptions = [
       "bold",
       "italic",
+      "underline",
       "code",
       "highlight",
       "strike",

--- a/lib/styles/components/_command-list.scss
+++ b/lib/styles/components/_command-list.scss
@@ -8,6 +8,7 @@
 }
 
 .editor-command-list--root {
+  @include scrollbars(4px);
   background: $neeto-ui-gray-800;
 
   .editor-command-list--item {


### PR DESCRIPTION
Fixes #65.
- Limited the height of the slash menu and added `overflow-y: scroll`.
- Changed `BubbleMenu` tooltip placement to `top-start`.
- Changed `BubbleMenu` `z-index` to appear above the neetoUI sidebar.
- Added underline option to `BubbleMenu`.
- Added highlight option to `FixedMenu`.

Please go through the following video: https://www.loom.com/share/7546a41921f7459f94ffc2d99a6cf472 