### PR TITLE
Removed the wrapper for the editor output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 
 # production
 /build
-/dist
 
 # misc
 .DS_Store

--- a/example/App.js
+++ b/example/App.js
@@ -10,11 +10,12 @@ import { Editor } from "../lib";
 
 import {
   EDITOR_FEATURES,
-  PROP_TABLE_COLUMNS,
-  PROP_TABLE_ROWS,
+  EDITOR_PROP_TABLE_COLUMNS,
+  EDITOR_PROP_TABLE_ROWS,
   SAMPLE_MENTIONS,
   SAMPLE_VARIABLES,
   STRINGS,
+  EDITOR_CONTENT_PROP_TABLE_ROWS,
 } from "./constants";
 import Table from "./components/Table";
 
@@ -45,20 +46,41 @@ const App = () => {
       <Editor ref={ref} />
       <Heading type="sub">Features</Heading>
       <ListItems items={EDITOR_FEATURES} ordered />
-
       <Heading>Installation</Heading>
       <CodeBlock>yarn add @bigbinary/neeto-editor</CodeBlock>
-
       <Heading>Usage</Heading>
-      <CodeBlock>import Editor from '@bigbinary/neeto-editor'</CodeBlock>
-
+      <CodeBlock>{`import { Editor } from '@bigbinary/neeto-editor'`}</CodeBlock>
       <Heading type="sub">All Props</Heading>
       <Table
-        columns={PROP_TABLE_COLUMNS}
-        rows={PROP_TABLE_ROWS}
+        columns={EDITOR_PROP_TABLE_COLUMNS}
+        rows={EDITOR_PROP_TABLE_ROWS}
         className="prop-detail-table"
       />
-
+      <Heading type="sub">Output</Heading>
+      <div className="mt-4">
+        <h3 className="mb-2 font-bold">Use EditorOutput component</h3>
+        <CodeBlock>
+          {`import { EditorOutput } from '@bigbinary/neeto-editor'`}
+        </CodeBlock>
+        <Table
+          columns={EDITOR_PROP_TABLE_COLUMNS}
+          rows={EDITOR_CONTENT_PROP_TABLE_ROWS}
+          className="prop-detail-table"
+        />
+      </div>
+      {/* <div className="mt-4">
+        <h3 className="mb-2 font-bold text-gray-700 ">
+          Include CSS in your project
+        </h3>
+        <CodeBlock>
+          {`import { EditorOutput } from '@bigbinary/neeto-editor'`}
+        </CodeBlock>
+        <Description>
+          You can use the above script to include css into your project. Add the
+          class <pre className="inline">neeto-editor-content</pre> to the
+          wrapper of the output content
+        </Description>
+      </div> */}
       <Heading type="sub">Fixed Menu</Heading>
       <Description>
         The default Neeto Editor layout comes with a set of always-on-top fixed
@@ -68,7 +90,6 @@ const App = () => {
         <CodeBlock>{STRINGS.fixedMenuSampleCode}</CodeBlock>
         <SampleEditor />
       </div>
-
       <Heading type="sub">Bubble Menu</Heading>
       <Description>
         If you would like to use an on-demand menu to interact with the editor
@@ -79,7 +100,6 @@ const App = () => {
         <CodeBlock>{STRINGS.bubbleMenuSampleCode}</CodeBlock>
         <SampleEditor menuType="bubble" />
       </div>
-
       <Heading type="sub">Slash Commands</Heading>
       <Description>
         Slash commands are actions that can be applied to block of text. This
@@ -92,7 +112,6 @@ const App = () => {
         <CodeBlock>{STRINGS.hideSlashCommandSampleCode}</CodeBlock>
         <SampleEditor hideSlashCommands />
       </div>
-
       <Heading type="sub">Variable Support</Heading>
       <Description>
         Neeto Editor supports variable placement. Pass array of variables as{" "}
@@ -111,7 +130,6 @@ const App = () => {
         <HighlightText>category_label</HighlightText> attributes. All other
         variables are shown under 'Others'
       </Description>
-
       <Heading type="sub">Support for Mentions</Heading>
       <Description>
         Neeto Editor comes with inbuilt support for mentions marking. Editor
@@ -135,7 +153,6 @@ const App = () => {
         <CodeBlock>{STRINGS.mentionsSampleCode}</CodeBlock>
         <SampleEditor mentions={SAMPLE_MENTIONS} showImageInMention />
       </div>
-
       <Heading type="sub">Support for placeholder</Heading>
       <Description>
         The editor can have placeholder texts for different nodes. These value
@@ -160,12 +177,10 @@ const App = () => {
           <HighlightText>{"({node}) => placeholder_text"}</HighlightText>
         </li>
       </ul>
-
       <div className="flex">
         <CodeBlock>{STRINGS.placeholderSampleCode}</CodeBlock>
         <SampleEditor placeholder="Input text here" />
       </div>
-
       <Heading type="sub">Force a title</Heading>
       <Description>
         Neeto editor can be configured to force user to include a document title

--- a/example/constants.js
+++ b/example/constants.js
@@ -39,9 +39,13 @@ export const SAMPLE_MENTIONS = [
   "Jaden Smith",
 ];
 
-export const PROP_TABLE_COLUMNS = ["Prop", "Description", "Sample Value"];
+export const EDITOR_PROP_TABLE_COLUMNS = [
+  "Prop",
+  "Description",
+  "Sample Value",
+];
 
-export const PROP_TABLE_ROWS = [
+export const EDITOR_PROP_TABLE_ROWS = [
   [
     "ref",
     "Accepts a React reference. This reference can be used to access TipTap's inbuilt editor methods, such as getHTML()",
@@ -110,6 +114,19 @@ export const PROP_TABLE_ROWS = [
   [
     "className",
     "Accepts a string value. Can be used for further customisation of the editor content layout.",
+    `"neeto-editor-content"`,
+  ],
+];
+
+export const EDITOR_CONTENT_PROP_TABLE_ROWS = [
+  [
+    "content",
+    "Accepts a valid HTML string. Can pass the output of the editor directly.",
+    `"<p>Hello World</p"`,
+  ],
+  [
+    "className",
+    "Accepts a string value. Can be used for further customisation of the editor content.",
     `"neeto-editor-content"`,
   ],
 ];

--- a/lib/components/Editor/EditorContent.js
+++ b/lib/components/Editor/EditorContent.js
@@ -1,8 +1,10 @@
 import React, { useEffect } from "react";
 import highlightCode from "utils/highlightCode";
 import DOMPurify from "dompurify";
+import classnames from "classnames";
+import { EDITOR_CONTENT_CLASSNAME } from "../../constants/common";
 
-const EditorContent = ({ content = "", ...otherProps }) => {
+const EditorContent = ({ content = "", classNames, ...otherProps }) => {
   useEffect(() => {
     // Highlight codeblocks;
     highlightCode();
@@ -10,6 +12,9 @@ const EditorContent = ({ content = "", ...otherProps }) => {
 
   return (
     <div
+      className={
+        (classnames(EDITOR_CONTENT_CLASSNAME), { [classNames]: classNames })
+      }
       dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
       {...otherProps}
     />

--- a/lib/components/Editor/index.js
+++ b/lib/components/Editor/index.js
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import classNames from "classnames";
 import { useEditor, EditorContent } from "@tiptap/react";
-import getWrappedHTML from "utils/getWrappedHTML";
 
 import BubbleMenu from "./CustomExtensions/BubbleMenu";
 import FixedMenu from "./CustomExtensions/FixedMenu";
@@ -71,16 +70,12 @@ const Tiptap = (
           }),
       },
     },
-    onUpdate: ({ editor }) =>
-      onChange(getWrappedHTML(editor, contentClassName)),
+    onUpdate: ({ editor }) => onChange(editor.getHTML()),
   });
 
   /* Make editor object available to the parent */
   React.useImperativeHandle(ref, () => ({
-    editor: {
-      ...editor,
-      getHTML: () => getWrappedHTML(editor, contentClassName),
-    },
+    editor: editor,
   }));
 
   return (

--- a/lib/constants/common.js
+++ b/lib/constants/common.js
@@ -1,1 +1,1 @@
-export const EDITOR_CONTENT_CLASSNAME = "tiptap-content";
+export const EDITOR_CONTENT_CLASSNAME = "neeto-editor-content";

--- a/lib/styles/components/_editor-content.scss
+++ b/lib/styles/components/_editor-content.scss
@@ -2,7 +2,7 @@
 
 $list-item-color: #1a141f;
 
-.tiptap-content {
+.neeto-editor-content {
   // Headers
   h1,
   h2,

--- a/lib/styles/components/_editor.scss
+++ b/lib/styles/components/_editor.scss
@@ -1,5 +1,5 @@
 .ProseMirror {
-  @extend .tiptap-content;
+  @extend .neeto-editor-content;
 
   max-width: 100% !important;
   border-radius: $neeto-ui-rounded-sm;

--- a/lib/styles/components/_fixed-menu.scss
+++ b/lib/styles/components/_fixed-menu.scss
@@ -6,7 +6,7 @@
   background: $neeto-ui-gray-200;
 
   button {
-    outline: none;
+    outline: none !important;
   }
 
   .editor-fixed-menu--item {

--- a/lib/utils/getWrappedHTML.js
+++ b/lib/utils/getWrappedHTML.js
@@ -1,8 +1,0 @@
-import { EDITOR_CONTENT_CLASSNAME } from "constants/common";
-
-export default (editor, className) => {
-  if (!editor) return "";
-
-  const classNameString = `${EDITOR_CONTENT_CLASSNAME} ${className || ""}`;
-  return `<div class="${classNameString}">${editor.getHTML()}</div`;
-};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = [
       ],
     },
     output: {
-      path: __dirname + "/build",
+      path: __dirname + "/dist",
       filename: "index.js",
       library: "neeto-editor",
       libraryTarget: "umd",


### PR DESCRIPTION
Fixes #67 

- Added Output section to documentation, which explains methods to display editor output content.
- Removed output content wrapper.
- Renamed output class name from `tiptap-content` to `neeto-editor-content`.

@labeebklatif _a Please review