### PR TITLE
limited file selection to one in media upload

### DIFF
--- a/lib/components/Editor/MediaUploader/constants.js
+++ b/lib/components/Editor/MediaUploader/constants.js
@@ -9,6 +9,7 @@ export const DEFAULT_IMAGE_UPPY_CONFIG = {
   autoProceed: true,
   allowMultipleUploads: false,
   restrictions: {
+    maxNumberOfFiles: 1,
     maxFileSize: MAX_IMAGE_SIZE,
     allowedFileTypes: ALLOWED_IMAGE_TYPES,
   },
@@ -18,6 +19,7 @@ export const DEFAULT_VIDEO_UPPY_CONFIG = {
   autoProceed: true,
   allowMultipleUploads: false,
   restrictions: {
+    maxNumberOfFiles: 1,
     maxFileSize: MAX_VIDEO_SIZE,
     allowedFileTypes: ALLOWED_VIDEO_TYPES,
   },


### PR DESCRIPTION
Fixes #486 

**Description**

- Changed: multiple media selection in file input to single.


**Reviewers**

@AbhayVAshokan _a
