### PR TITLE
Added className prop to Headless menu component

### DIFF
--- a/lib/components/Editor/Menu/Headless/index.jsx
+++ b/lib/components/Editor/Menu/Headless/index.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import classnames from "classnames";
+
 import Option from "./Option";
 import { buildMenuOptions } from "./utils";
 
@@ -11,6 +13,7 @@ const Headless = ({
   setMediaUploader,
   addonCommands = [],
   children,
+  className,
 }) => {
   if (!editor) {
     return null;
@@ -24,7 +27,7 @@ const Headless = ({
   const allOptions = [...menuOptions, ...addonCommandOptions];
 
   return (
-    <div className="ne-headless">
+    <div className={classnames("ne-headless", { [className]: className })}>
       {allOptions.map(option => (
         <Option editor={editor} key={option.optionName} {...option} />
       ))}


### PR DESCRIPTION
Fixes #523 

**Description**

- Added: `className` prop to the `Headless` menu component.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
