### PR TITLE
Added types for attachments

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -113,6 +113,7 @@ type attachment = {
   filename?: string;
   signedId?: string;
   url?: string;
+  [otherProps: string]: any;
 };
 interface AttachmentsProps {
   endpoint?: string;

--- a/types.d.ts
+++ b/types.d.ts
@@ -109,9 +109,23 @@ interface FormikEditorProps extends EditorProps {
   name: string;
 }
 
+type attachment = {
+  filename?: string;
+  signedId?: string;
+  url?: string;
+};
+interface AttachmentsProps {
+  endpoint?: string;
+  attachments?: Array<attachment>;
+  onChange: (attachments: attachment[]) => void;
+}
+
+
 export function Editor(props: EditorProps): JSX.Element;
 
 export function FormikEditor(props: FormikEditorProps): JSX.Element;
+
+export function Attachments(props: AttachmentsProps): JSX.Element;
 
 export function EditorContent(props: {
   content?: string;


### PR DESCRIPTION
Fixes #515 

**Description**

- Added: types for _Attachment_ component.

**Checklist**

- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**
@AbhayVAshokan _a