### PR TITLE
Added file icons according to file type

### DIFF
--- a/lib/components/Attachments/Attachment.jsx
+++ b/lib/components/Attachments/Attachment.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 
 import saveAs from "file-saver";
-import { MenuVertical, File, Close } from "neetoicons";
+import { MenuVertical, Close } from "neetoicons";
 import {
   Dropdown,
   Input,
@@ -16,6 +16,7 @@ import { isEmpty, assoc } from "ramda";
 import directUploadsApi from "apis/direct_uploads";
 
 import { ATTACHMENT_OPTIONS } from "./constants";
+import FileIcon from "./FileIcon";
 
 const { Menu, MenuItem } = Dropdown;
 
@@ -127,7 +128,7 @@ const Attachment = ({ attachment, endpoint, onChange, attachments }) => {
           </>
         ) : (
           <>
-            <File size={16} />
+            <FileIcon fileName={attachment.filename} />
             <Tooltip content={attachment.filename} position="top">
               <Typography style="body2">{attachment.filename}</Typography>
             </Tooltip>

--- a/lib/components/Attachments/FileIcon.jsx
+++ b/lib/components/Attachments/FileIcon.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import { FileIcon, defaultStyles } from "react-file-icon";
+
+const File = ({ fileName }) => {
+  const extension = fileName.match(/([^.]+)$/)[1];
+
+  return (
+    <div className="ne-attachments__attachment-file-icon">
+      <FileIcon {...defaultStyles[extension]} extension={extension} />
+    </div>
+  );
+};
+
+export default File;

--- a/lib/styles/components/_attachments.scss
+++ b/lib/styles/components/_attachments.scss
@@ -18,6 +18,12 @@
     border: 1px solid rgb(var(--neeto-ui-gray-200));
     width: 256px;
 
+    &-file-icon {
+      height: auto;
+      width: 15px;
+    }
+
+
     &__progress {
       display: flex;
       opacity: 0.5;

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "re-resizable": "6.9.9",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-file-icon": "^1.3.0",
     "react-hotkeys-hook": "3.4.7",
     "react-masonry-infinite": "1.2.2",
     "react-popper": "2.3.0",

--- a/stories/Walkthroughs/Attachments/constants.js
+++ b/stories/Walkthroughs/Attachments/constants.js
@@ -20,7 +20,7 @@ export const EDITOR_ADDONS_TABLE_ROWS = [
 
 export const ATTACHMENTS = [
   {
-    filename: "Books.jpg",
+    filename: "Books.pdf",
     url: "https://i.picsum.photos/id/24/4855/1803.jpg?hmac=ICVhP1pUXDLXaTkgwDJinSUS59UWalMxf4SOIWb9Ui4",
     signedId: "1",
   },


### PR DESCRIPTION
Fixes #548 

**Description**

- Changed: attachments to show icons of specific file types

**Checklist**

- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a