### PR TITLE
Added a disabled prop to conditionally disable actions on attachment

### DIFF
--- a/lib/components/Attachments/Attachment.jsx
+++ b/lib/components/Attachments/Attachment.jsx
@@ -15,12 +15,18 @@ import { isEmpty, assoc } from "ramda";
 
 import directUploadsApi from "apis/direct_uploads";
 
-import { ATTACHMENT_OPTIONS } from "./constants";
+import { ATTACHMENT_OPTIONS, OPTIONS_DISABLED_MESSAGE } from "./constants";
 import FileIcon from "./FileIcon";
 
 const { Menu, MenuItem } = Dropdown;
 
-const Attachment = ({ attachment, endpoint, onChange, attachments }) => {
+const Attachment = ({
+  attachment,
+  endpoint,
+  onChange,
+  attachments,
+  isDisabled,
+}) => {
   const [isRenaming, setIsRenaming] = useState(false);
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -132,18 +138,30 @@ const Attachment = ({ attachment, endpoint, onChange, attachments }) => {
             <Tooltip content={attachment.filename} position="top">
               <Typography style="body2">{attachment.filename}</Typography>
             </Tooltip>
-            <Dropdown buttonStyle="text" icon={MenuVertical}>
-              <Menu>
-                {Object.entries(handlers).map(([label, handler]) => (
-                  <MenuItem.Button
-                    key={label}
-                    onClick={() => onMenuItemClick({ key: label, handler })}
-                  >
-                    {label}
-                  </MenuItem.Button>
-                ))}
-              </Menu>
-            </Dropdown>
+            <Tooltip
+              content={OPTIONS_DISABLED_MESSAGE}
+              disabled={!isDisabled}
+              position="top"
+            >
+              <div>
+                <Dropdown
+                  buttonStyle="text"
+                  disabled={isDisabled}
+                  icon={MenuVertical}
+                >
+                  <Menu>
+                    {Object.entries(handlers).map(([label, handler]) => (
+                      <MenuItem.Button
+                        key={label}
+                        onClick={() => onMenuItemClick({ key: label, handler })}
+                      >
+                        {label}
+                      </MenuItem.Button>
+                    ))}
+                  </Menu>
+                </Dropdown>
+              </div>
+            </Tooltip>
           </>
         )}
       </div>

--- a/lib/components/Attachments/Attachment.jsx
+++ b/lib/components/Attachments/Attachment.jsx
@@ -94,6 +94,7 @@ const Attachment = ({
   };
 
   const handleKeyDown = ({ event, key }) => {
+    event.preventDefault();
     const handler = handlers[key];
 
     if (event.key === "Enter" && handler && !isEmpty(newFilename)) {

--- a/lib/components/Attachments/Attachment.jsx
+++ b/lib/components/Attachments/Attachment.jsx
@@ -15,7 +15,7 @@ import { isEmpty, assoc } from "ramda";
 
 import directUploadsApi from "apis/direct_uploads";
 
-import { ATTACHMENT_OPTIONS, OPTIONS_DISABLED_MESSAGE } from "./constants";
+import { ATTACHMENT_OPTIONS } from "./constants";
 import FileIcon from "./FileIcon";
 
 const { Menu, MenuItem } = Dropdown;
@@ -25,7 +25,7 @@ const Attachment = ({
   endpoint,
   onChange,
   attachments,
-  isDisabled,
+  disabled,
 }) => {
   const [isRenaming, setIsRenaming] = useState(false);
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState(false);
@@ -140,14 +140,14 @@ const Attachment = ({
               <Typography style="body2">{attachment.filename}</Typography>
             </Tooltip>
             <Tooltip
-              content={OPTIONS_DISABLED_MESSAGE}
-              disabled={!isDisabled}
+              content="You are not permitted to update or delete attachments"
+              disabled={!disabled}
               position="top"
             >
-              <div>
+              <span>
                 <Dropdown
                   buttonStyle="text"
-                  disabled={isDisabled}
+                  disabled={disabled}
                   icon={MenuVertical}
                 >
                   <Menu>
@@ -161,7 +161,7 @@ const Attachment = ({
                     ))}
                   </Menu>
                 </Dropdown>
-              </div>
+              </span>
             </Tooltip>
           </>
         )}

--- a/lib/components/Attachments/constants.js
+++ b/lib/components/Attachments/constants.js
@@ -8,9 +8,6 @@ export const DEFAULT_UPPY_CONFIG = {
   },
 };
 
-export const OPTIONS_DISABLED_MESSAGE =
-  "You cannot update or delete this attachment";
-
 export const UPPY_UPLOAD_CONFIG = { formData: true, fieldName: "blob" };
 
 export const ATTACHMENT_OPTIONS = {

--- a/lib/components/Attachments/constants.js
+++ b/lib/components/Attachments/constants.js
@@ -8,6 +8,9 @@ export const DEFAULT_UPPY_CONFIG = {
   },
 };
 
+export const OPTIONS_DISABLED_MESSAGE =
+  "You cannot update or delete this attachment";
+
 export const UPPY_UPLOAD_CONFIG = { formData: true, fieldName: "blob" };
 
 export const ATTACHMENT_OPTIONS = {

--- a/lib/components/Attachments/index.jsx
+++ b/lib/components/Attachments/index.jsx
@@ -19,6 +19,7 @@ const Attachments = (
     className = "",
     onChange = _ => {},
     isIndependent = true,
+    isDisabled = true,
     dragDropRef = null,
   },
   ref
@@ -120,6 +121,7 @@ const Attachments = (
             attachment={attachment}
             attachments={attachments}
             endpoint={endpoint}
+            isDisabled={isDisabled}
             key={attachment.signedId}
             onChange={onChange}
           />

--- a/lib/components/Attachments/index.jsx
+++ b/lib/components/Attachments/index.jsx
@@ -19,7 +19,7 @@ const Attachments = (
     className = "",
     onChange = _ => {},
     isIndependent = true,
-    isDisabled = true,
+    disabled = false,
     dragDropRef = null,
   },
   ref
@@ -120,8 +120,8 @@ const Attachments = (
           <Attachment
             attachment={attachment}
             attachments={attachments}
+            disabled={disabled}
             endpoint={endpoint}
-            isDisabled={isDisabled}
             key={attachment.signedId}
             onChange={onChange}
           />

--- a/stories/Walkthroughs/Attachments/Attachments.stories.mdx
+++ b/stories/Walkthroughs/Attachments/Attachments.stories.mdx
@@ -73,3 +73,10 @@ The attachments prop is an array of objects with the following structure:
     <Attachments attachments={attachments} onChange={setAttachments} />
   </Story>
 </Canvas>
+
+### **With options disabled**
+<Canvas>
+  <Story name="With options disabled">
+    <Attachments attachments={attachments} onChange={setAttachments} isIndependent={false} disabled />
+  </Story>
+</Canvas>

--- a/stories/Walkthroughs/Attachments/CustomDragDropDemo.jsx
+++ b/stories/Walkthroughs/Attachments/CustomDragDropDemo.jsx
@@ -20,7 +20,7 @@ const CustomDragDropDemo = () => {
           </Typography>
         </Pane.Header>
         <div
-          className="flex justify-center w-full h-full ne-attachments__wrapper"
+          className="flex justify-center w-full ne-attachments__wrapper h-96"
           ref={dragDropRef}
         >
           <Attachments

--- a/stories/Walkthroughs/Attachments/constants.js
+++ b/stories/Walkthroughs/Attachments/constants.js
@@ -17,7 +17,7 @@ export const EDITOR_ADDONS_TABLE_ROWS = [
     "Ref for the Attachments component. This ref needs to be used for accessing the handleUploadAttachment function.",
   ],
   [
-    "isDisabled",
+    "disabled",
     "If true, the options to download, rename and delete the attachments will be disabled.",
   ],
 ];

--- a/stories/Walkthroughs/Attachments/constants.js
+++ b/stories/Walkthroughs/Attachments/constants.js
@@ -16,6 +16,10 @@ export const EDITOR_ADDONS_TABLE_ROWS = [
     "ref",
     "Ref for the Attachments component. This ref needs to be used for accessing the handleUploadAttachment function.",
   ],
+  [
+    "isDisabled",
+    "If true, the options to download, rename and delete the attachments will be disabled.",
+  ],
 ];
 
 export const attachments = [

--- a/types.d.ts
+++ b/types.d.ts
@@ -121,6 +121,9 @@ interface AttachmentsProps {
   attachments?: Array<attachment>;
   dragDropRef?: React.RefObject<HTMLDivElement>;
   onChange: (attachments: attachment[]) => void;
+  isIndependent?: boolean;
+  disabled?: boolean;
+  className?: string;
 }
 
 export function Editor(props: EditorProps): JSX.Element;


### PR DESCRIPTION
Fixes #556 

**Description**

- Added: prop to determine if actions on attachments are disabled

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a