### PR TITLE
Exposed substituteVariables method from neetoEditor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+import { substituteVariables } from "components/EditorContent/utils";
 import { isEditorEmpty } from "utils/common";
 
 import Attachments from "./components/Attachments";
@@ -12,6 +13,7 @@ export {
   EditorContent,
   Menu,
   isEditorEmpty,
+  substituteVariables,
   FormikEditor,
   Attachments,
 };

--- a/stories/Examples/Variables.stories.mdx
+++ b/stories/Examples/Variables.stories.mdx
@@ -56,7 +56,9 @@ typing`{{` within the editor.
 </Canvas>
 
 ### **Usage**
+
 following is the example of how to use variables in neetoEditor.
+
 <VariablesDemo />
 
 <br />
@@ -107,3 +109,14 @@ following is the example of how to use variables in neetoEditor.
   },
 ];
 ```
+
+### **substituteVariables** method
+
+The `substituteVariables` method can be used to substitute the variables of the
+editor content with the associated values.
+
+```jsx
+const parsedEditorContent = substituteVariables(editorContent, variables);
+```
+
+Here `variables` is an array of the above mentioned format.


### PR DESCRIPTION
Fixes #577 

**Description**

- Exposed `substitueValues` method from neetoEditor.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@AbhayVAshokan _a

<!---
------------- FORMAT FOR DESCRIPTION -------------

Prefix the change with one of these keywords:
- Added: for new features.
- Changed: for changes in existing functionality.
- Deprecated: for soon-to-be removed features.
- Removed: for now removed features.
- Fixed: for any bug fixes.
- Security: in case of vulnerabilities.

Points to note:
- The description shall be represented in bullet points.
- Add the keyword BREAKING in bold style for changes that could potentially break the component, eg: **BREAKING**.
- Represent a component name in italics, eg: _Modal_.
- Enclose a prop name in double backticks, eg: `menuType`.
--->
