### PR TITLE
Fixed issues with headless menu

### DIFF
--- a/lib/components/Editor/Menu/Headless/Option/Emoji.jsx
+++ b/lib/components/Editor/Menu/Headless/Option/Emoji.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { Smiley } from "neetoicons";
 
@@ -6,30 +6,22 @@ import EmojiPicker from "components/Editor/CustomExtensions/Emoji/EmojiPicker/Em
 
 import Dropdown from "./UI/Dropdown";
 
-const Emoji = ({ editor, isActive, setActive, tooltipContent }) => {
-  const [isOpen, setIsOpen] = useState(false);
-
-  return (
-    <Dropdown
-      className="ne-headless__emoji"
-      icon={Smiley}
-      isOpen={isOpen || isActive}
-      buttonProps={{
-        tooltipProps: {
-          content: tooltipContent,
-          delay: [500],
-          position: "bottom",
-        },
-      }}
-      onClick={() => setIsOpen(open => !open)}
-      onClose={() => {
-        setIsOpen(false);
-        setActive(false);
-      }}
-    >
-      <EmojiPicker editor={editor} />
-    </Dropdown>
-  );
-};
-
+const Emoji = ({ editor, isActive, setActive, tooltipContent }) => (
+  <Dropdown
+    className="ne-headless__emoji"
+    icon={Smiley}
+    isOpen={isActive}
+    buttonProps={{
+      tooltipProps: {
+        content: tooltipContent,
+        delay: [500],
+        position: "bottom",
+      },
+    }}
+    onClick={() => setActive(active => !active)}
+    onClose={() => setActive(false)}
+  >
+    <EmojiPicker editor={editor} setActive={setActive} />
+  </Dropdown>
+);
 export default Emoji;

--- a/lib/components/Editor/Menu/Headless/Option/index.jsx
+++ b/lib/components/Editor/Menu/Headless/Option/index.jsx
@@ -11,16 +11,24 @@ const Option = ({
   command,
   disabled,
   Icon,
-  active,
+  isActive,
+  setActive,
   tooltip,
 }) => {
   if (optionName === EDITOR_OPTIONS.EMOJI) {
-    return <Emoji editor={editor} tooltipContent={tooltip.emoji || "Emoji"} />;
+    return (
+      <Emoji
+        editor={editor}
+        isActive={isActive}
+        setActive={setActive}
+        tooltipContent={tooltip || "Emoji"}
+      />
+    );
   }
 
   return (
     <Button
-      className={active ? "ne-headless-btn--active" : ""}
+      className={isActive ? "ne-headless-btn--active" : ""}
       disabled={disabled}
       icon={Icon}
       tooltipProps={{

--- a/lib/components/Editor/Menu/index.jsx
+++ b/lib/components/Editor/Menu/index.jsx
@@ -40,21 +40,26 @@ const Menu = props => {
     ? [...DEFAULT_EDITOR_OPTIONS, ...addons]
     : options;
 
-  const handleKeyDown = e => {
-    if ((e.metaKey || e.ctrlKey) && e.altKey) {
-      if (e.code === "KeyE") {
-        setIsEmojiPickerActive(prevState => !prevState);
-      } else if (e.code === "KeyA") {
-        handleUploadAttachments();
-      } else if (e.code === "KeyK") {
-        setMediaUploader(assoc("image", true));
-      } else if (e.code === "KeyV") {
-        setMediaUploader(assoc("video", true));
+  useEffect(() => {
+    const handleKeyDown = e => {
+      if ((e.metaKey || e.ctrlKey) && e.altKey) {
+        if (e.code === "KeyE") {
+          setIsEmojiPickerActive(prevState => !prevState);
+        } else if (e.code === "KeyA") {
+          handleUploadAttachments();
+        } else if (e.code === "KeyK") {
+          setMediaUploader(assoc("image", true));
+        } else if (e.code === "KeyV") {
+          setMediaUploader(assoc("video", true));
+        }
       }
-    }
-  };
+    };
+    document.addEventListener("keydown", handleKeyDown);
 
-  useEffect(() => document.addEventListener("keydown", handleKeyDown), []);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
 
   return (
     <>

--- a/stories/constants.js
+++ b/stories/constants.js
@@ -55,10 +55,10 @@ export const EDITOR_SHORTCUTS_TABLE_ROWS = [
   ["Ordered List", "Ctrl + Shift + 7", "Cmd + Shift + 7"],
   ["Bullet List", "Ctrl + Shift + 8", "Cmd + Shift + 8"],
   ["Blockquote", "Ctrl + Shift + B", "Cmd + Shift + B"],
-  ["Emoji", "Ctrl + Shift + E", "Cmd + Shift + E"],
-  ["Vieo uploader", "Ctrl + Shift + V", "Cmd + Shift + V"],
-  ["Image uploader", "Ctrl + Shift + I", "Cmd + Shift + k"],
-  ["Upload attachments", "Ctrl + Shift + A", "Cmd + Shift + A"],
+  ["Emoji", "Ctrl + Alt + E", "Cmd + Opt + E"],
+  ["Video uploader", "Ctrl + Alt + V", "Cmd + Opt + V"],
+  ["Image uploader", "Ctrl + Alt + I", "Cmd + Opt + K"],
+  ["Upload attachments", "Ctrl + Alt + A", "Cmd + Opt + A"],
 ];
 
 export const CUSTOM_SLASH_COMMANDS_TABLE_COLUMNS = ["Property", "Description"];


### PR DESCRIPTION
Fixes #580 

**Description**

-  Fixed: emoji picker not closing.
-  Fixed: Emoji picker tooltip is not updating after passing tooltips prop.
-  Changed: documentation for keyboard shortcuts.
-  Fixed: Emoji picker is not opening with Cmd+Shift+E in macOs.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary label (patch/minor/major - If package publish is required).

**Reviewers**

@mohitharshan123 _a

