### PR TITLE
Sets the default size of the Editor and EditorContent to small size.

### DIFF
--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -69,7 +69,7 @@ const Editor = (
     openLinkInNewTab = true,
     collaborationProvider = null,
     enableReactNodeViewOptimization = false,
-    size = EDITOR_SIZES.MEDIUM,
+    size = EDITOR_SIZES.SMALL,
     ...otherProps
   },
   ref

--- a/src/components/EditorContent/index.jsx
+++ b/src/components/EditorContent/index.jsx
@@ -26,7 +26,7 @@ const EditorContent = ({
   content = "",
   variables = [],
   className,
-  size = EDITOR_SIZES.MEDIUM,
+  size = EDITOR_SIZES.SMALL,
   configuration = EDITOR_CONTENT_DEFAULT_CONFIGURATION,
   ...otherProps
 }) => {


### PR DESCRIPTION
Fixes #1266

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
