### PR TITLE
Added an explicit check before joining bullet list with previous node

### DIFF
--- a/src/components/Editor/CustomExtensions/BulletList/ExtensionConfig.js
+++ b/src/components/Editor/CustomExtensions/BulletList/ExtensionConfig.js
@@ -37,7 +37,14 @@ export default BulletList.extend({
           }
 
           if (currentIndex === 0) {
-            return commands.joinBackward();
+            const before = state.doc.resolve($from.before($from.depth));
+            const beforeNode = before.nodeBefore;
+
+            if (beforeNode && isListNode(beforeNode)) {
+              return commands.joinBackward();
+            }
+
+            return commands.deleteCurrentNode();
           }
 
           // Delete the empty paragraph node between the two lists.


### PR DESCRIPTION
- Fixes https://github.com/bigbinary/neeto-kb-web/issues/7820

**Description**

- Added an explicit check whether the nodes are compatible before joining the bullet list with the previous node. If not, the current node is deleted without joining.

**Checklist**

- [x] ~I have made corresponding changes to the documentation.~
- [x] ~I have updated the types definition of modified exports.~
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
