### PR TITLE
Transform plain text into HTML before rendering it in EditorContent and transform the content by stripping of the colors

### DIFF
--- a/src/components/Editor/utils.js
+++ b/src/components/Editor/utils.js
@@ -73,8 +73,17 @@ export const transformEditorContent = content =>
 export const isEmojiSuggestionsMenuActive = () =>
   !!document.querySelector(".neeto-editor-emoji-suggestion");
 
-export const transformPastedHTML = content =>
-  content.replaceAll("<br />", "<p></p>");
+export const transformPastedHTML = content => {
+  const contentWithoutBr = content.replaceAll("<br />", "<p></p>");
+  const doc = new DOMParser().parseFromString(contentWithoutBr, "text/html");
+
+  doc.querySelectorAll("[style]").forEach(el => {
+    el.style.color = "";
+    el.style.backgroundColor = "";
+  });
+
+  return doc.body.innerHTML;
+};
 
 export const buildLevelsFromOptions = options => {
   const levels = {

--- a/src/components/EditorContent/index.jsx
+++ b/src/components/EditorContent/index.jsx
@@ -20,6 +20,7 @@ import {
   substituteVariables,
   applyLineHighlighting,
   applySyntaxHighlightingAndLineNumbers,
+  convertPlainTextToHtml,
 } from "./utils";
 import { buildHeaderLinks } from "./utils/headers";
 
@@ -34,9 +35,11 @@ const EditorContent = ({
   const [imagePreviewDetails, setImagePreviewDetails] = useState(null);
   const editorContentRef = useRef(null);
 
-  const htmlContent = substituteVariables(
-    applySyntaxHighlightingAndLineNumbers(removeEmptyTags(content)),
-    variables
+  const htmlContent = convertPlainTextToHtml(
+    substituteVariables(
+      applySyntaxHighlightingAndLineNumbers(removeEmptyTags(content)),
+      variables
+    )
   );
   const sanitize = DOMPurify.sanitize;
 

--- a/src/components/EditorContent/utils/index.js
+++ b/src/components/EditorContent/utils/index.js
@@ -142,3 +142,11 @@ export const substituteVariables = (highlightedContent, variables) =>
 
     return variable?.value ? variable.value : matchedSpan;
   });
+
+export const convertPlainTextToHtml = htmlString => {
+  if (/^<\/[a-z].*>/i.test(htmlString.trim())) return htmlString;
+
+  return htmlString
+    .split("\n")
+    .reduce((html, str) => `${html}<p>${str}</p>`, "");
+};


### PR DESCRIPTION
- Fixes https://github.com/bigbinary/neeto-editor/issues/1429

**Description**

- Transform plain text into HTML before rendering it in EditorContent and transform the content by stripping of the colors.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
