### PR TITLE
Left align Table content

### DIFF
--- a/src/styles/editor/editor-content.scss
+++ b/src/styles/editor/editor-content.scss
@@ -800,6 +800,7 @@
       border-top: 1px solid rgba(var(--neeto-editor-gray-300));
       padding: 8px 12px;
       position: relative;
+      text-align: left;
     }
 
     td:first-child,


### PR DESCRIPTION
- Fixes #1509 

### Changes

- Left-aligned the table content.

<img width="1440" height="900" alt="Group 1" src="https://github.com/user-attachments/assets/2dc8edb6-29bf-4605-81ba-e278c856b2c2" />

@praveen-murali-ind _a

**Description**

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
