### PR TITLE
Prevent the upload of corrupted files

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -42,7 +42,8 @@
       "uploadFileFailed": "Attachment upload failed",
       "fileNotAllowed": "The selected file type is not allowed",
       "noResults": "No results",
-      "imageUploadFailed": "Image upload failed, please try again!"
+      "imageUploadFailed": "Image upload failed, please try again!",
+      "corruptFile": "This file is corrupted. Please try again with another"
     },
     "menu": {
       "attachments": "Attachments",

--- a/src/utils/DirectUpload/index.js
+++ b/src/utils/DirectUpload/index.js
@@ -1,3 +1,4 @@
+import i18n from "i18next";
 import { noop } from "neetocist";
 
 import directUploadsApi from "apis/direct_uploads";
@@ -13,6 +14,10 @@ class DirectUpload {
   }
 
   create = async () => {
+    if (!this.file.name || !this.file.size) {
+      throw new Error(i18n.t("neetoEditor.error.corruptFile"));
+    }
+
     const response = await this.generateUrl();
     const { url, headers } =
       response.direct_upload || response.data.direct_upload;


### PR DESCRIPTION
- Fixes https://github.com/neetozone/neeto-editor/issues/1495

**Description**

- Prevent the upload of corrupted files by explicitly throwing an error.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
