### PR TITLE
Fixes image resize limit

### DIFF
--- a/src/components/Editor/CustomExtensions/Image/ImageComponent.jsx
+++ b/src/components/Editor/CustomExtensions/Image/ImageComponent.jsx
@@ -73,7 +73,7 @@ const ImageComponent = ({
           <Resizable
             lockAspectRatio
             className="neeto-editor__image"
-            minWidth="100px"
+            minWidth="50px"
             size={{ height, width }}
             onResizeStop={handleResizeStop}
             onResize={(_event, _direction, ref) =>

--- a/src/components/Editor/MediaUploader/index.jsx
+++ b/src/components/Editor/MediaUploader/index.jsx
@@ -85,17 +85,11 @@ const MediaUploader = ({ mediaUploader, onClose, editor }) => {
       onClose={handleClose}
     >
       <div className="ne-media-uploader">
-        {mediaUploader.video && (
+        {(mediaUploader.video || mediaUploader.image) && (
           <div className="ne-media-uploader__header">
             <h2 className="ne-media-uploader__header-title">
-              {t("neetoEditor.menu.addVideo")}
-            </h2>
-          </div>
-        )}
-        {mediaUploader.image && (
-          <div className="ne-media-uploader__header">
-            <h2 className="ne-media-uploader__header-title">
-              {t("neetoEditor.menu.addImage")}
+              {mediaUploader.video && t("neetoEditor.menu.addVideo")}
+              {mediaUploader.image && t("neetoEditor.menu.addImage")}
             </h2>
           </div>
         )}


### PR DESCRIPTION
- Fixes #1600 
Reduced the resize limit to `50px`. Anything below this will be smaller than the action dropdown icon and this seems to be a safe limit