### PR TITLE
Disabled attachment preview for HTML files to prevent preview errors

### DIFF
--- a/src/components/Attachments/utils.js
+++ b/src/components/Attachments/utils.js
@@ -37,8 +37,6 @@ export const checkPreviewAvailability = contentType =>
     contentType === "application/msword" ||
     contentType ===
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
-    contentType === "text/htm" ||
-    contentType === "text/html" ||
     contentType === "image/jpg" ||
     contentType === "application/vnd.ms-powerpoint" ||
     contentType ===


### PR DESCRIPTION
- Fixes #1707 

**Description**
- Removed the `text/htm` and `text/html` content types to prevent preview errors for HTML files.
- An open issue exists in `react-doc-viewer` reporting the same error: https://github.com/Alcumus/react-doc-viewer/issues/78

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
