### PR TITLE
Fixed TypeError setActive is not a function

### DIFF
--- a/src/components/Editor/CustomExtensions/Emoji/EmojiPicker/EmojiPickerMenu.jsx
+++ b/src/components/Editor/CustomExtensions/Emoji/EmojiPicker/EmojiPickerMenu.jsx
@@ -49,7 +49,7 @@ class EmojiPickerMenu extends React.Component {
       .deleteRange(this.props.range)
       .setEmoji(emoji)
       .run();
-    this.props.setActive(false);
+    this.props.setActive?.(false);
   };
 
   render() {


### PR DESCRIPTION
- Fixes https://github.com/neetozone/neeto-cal-web/issues/21134

**Description**

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
