### PR TITLE
Enhanced attachment menu

### DIFF
--- a/src/components/Attachments/Attachment.jsx
+++ b/src/components/Attachments/Attachment.jsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 
 import { removeBy } from "neetocist";
+import useOnClickOutside from "neetocommons/react-utils/useOnClickOutside";
 import { withEventTargetValue } from "neetocommons/utils";
-import { MenuVertical, Close } from "neetoicons";
+import { MenuVertical, Close, Check } from "neetoicons";
 import {
   Dropdown,
   Input,
@@ -42,6 +43,14 @@ const Attachment = ({
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [newFilename, setNewFilename] = useState("");
+
+  const renameRef = useRef(null);
+
+  useOnClickOutside(renameRef, () => {
+    if (!isRenaming) return;
+    setIsRenaming(false);
+    setNewFilename("");
+  });
 
   const handleDownload = () =>
     downloadFile(attachment.url, attachment.filename);
@@ -129,7 +138,7 @@ const Attachment = ({
         data-testid="ne-attachments-wrapper"
       >
         {isRenaming ? (
-          <>
+          <div ref={renameRef}>
             <Tooltip content={newFilename} position="top">
               <Input
                 autoFocus
@@ -141,6 +150,30 @@ const Attachment = ({
                     ? t("neetoEditor.attachments.nameEmpty")
                     : ""
                 }
+                suffix={
+                  <div className="flex items-center justify-end">
+                    <Button
+                      data-testid="neeto-editor-preview-rename-submit-button"
+                      disabled={isEmpty(newFilename) || isUpdating}
+                      icon={Check}
+                      loading={isUpdating}
+                      size="small"
+                      style="text"
+                      onClick={handleRename}
+                    />
+                    <Button
+                      data-testid="neeto-editor-preview-rename-cancel-button"
+                      disabled={isUpdating}
+                      icon={Close}
+                      size="small"
+                      style="text"
+                      onClick={() => {
+                        setIsRenaming(false);
+                        setNewFilename("");
+                      }}
+                    />
+                  </div>
+                }
                 onChange={withEventTargetValue(setNewFilename)}
                 onKeyDown={event =>
                   handleKeyDown({
@@ -150,15 +183,7 @@ const Attachment = ({
                 }
               />
             </Tooltip>
-            <Button
-              data-testid="neeto-editor-preview-rename-cancel-button"
-              icon={Close}
-              loading={isUpdating}
-              size="small"
-              style="text"
-              onClick={() => setIsRenaming(false)}
-            />
-          </>
+          </div>
         ) : (
           <>
             <div

--- a/src/components/Attachments/Attachment.jsx
+++ b/src/components/Attachments/Attachment.jsx
@@ -55,7 +55,8 @@ const Attachment = ({
   const handleDownload = () =>
     downloadFile(attachment.url, attachment.filename);
 
-  const handleOpenInNewTab = () => window.open(attachment.url, "_blank");
+  const handleOpenInNewTab = () =>
+    window.open(attachment.url, "_blank", "noopener,noreferrer");
 
   const handleRename = async () => {
     try {
@@ -217,7 +218,7 @@ const Attachment = ({
                       key={label}
                       onClick={() => onMenuItemClick({ key: label, handler })}
                     >
-                      {label}
+                      {t(label)}
                     </MenuItem.Button>
                   ))}
                 </Menu>

--- a/src/components/Attachments/Attachment.jsx
+++ b/src/components/Attachments/Attachment.jsx
@@ -33,6 +33,7 @@ const Attachment = ({
   setSelectedAttachment,
   isLoading,
   allowDelete,
+  allowOpenInNewTab,
 }) => {
   const { t } = useTranslation();
 
@@ -44,6 +45,8 @@ const Attachment = ({
 
   const handleDownload = () =>
     downloadFile(attachment.url, attachment.filename);
+
+  const handleOpenInNewTab = () => window.open(attachment.url, "_blank");
 
   const handleRename = async () => {
     try {
@@ -84,6 +87,9 @@ const Attachment = ({
   };
 
   const handlers = {
+    ...(allowOpenInNewTab && {
+      [ATTACHMENT_OPTIONS.OPEN_IN_NEW_TAB]: handleOpenInNewTab,
+    }),
     [ATTACHMENT_OPTIONS.DOWNLOAD]: handleDownload,
     [ATTACHMENT_OPTIONS.RENAME]: handleRename,
     ...(allowDelete && { [ATTACHMENT_OPTIONS.DELETE]: handleDelete }),
@@ -118,7 +124,10 @@ const Attachment = ({
 
   return (
     <>
-      <div className="ne-attachments__preview" data-testid="ne-attachments-wrapper">
+      <div
+        className="ne-attachments__preview"
+        data-testid="ne-attachments-wrapper"
+      >
         {isRenaming ? (
           <>
             <Tooltip content={newFilename} position="top">

--- a/src/components/Attachments/Attachment.jsx
+++ b/src/components/Attachments/Attachment.jsx
@@ -218,7 +218,7 @@ const Attachment = ({
                       key={label}
                       onClick={() => onMenuItemClick({ key: label, handler })}
                     >
-                      {t(label)}
+                      {label}
                     </MenuItem.Button>
                   ))}
                 </Menu>

--- a/src/components/Attachments/constants.js
+++ b/src/components/Attachments/constants.js
@@ -10,6 +10,7 @@ export const DEFAULT_FILE_UPLOAD_CONFIG = {
 };
 
 export const ATTACHMENT_OPTIONS = {
+  OPEN_IN_NEW_TAB: "Open in new tab",
   DOWNLOAD: "Download",
   RENAME: "Rename",
   DELETE: "Delete",

--- a/src/components/Attachments/constants.js
+++ b/src/components/Attachments/constants.js
@@ -10,10 +10,10 @@ export const DEFAULT_FILE_UPLOAD_CONFIG = {
 };
 
 export const ATTACHMENT_OPTIONS = {
-  OPEN_IN_NEW_TAB: "Open in new tab",
-  DOWNLOAD: "Download",
-  RENAME: "Rename",
-  DELETE: "Delete",
+  OPEN_IN_NEW_TAB: "neetoEditor.common.openInNewTab",
+  DOWNLOAD: "neetoEditor.common.download",
+  RENAME: "neetoEditor.attachments.rename",
+  DELETE: "neetoEditor.menu.delete",
 };
 
 export const ATTACHMENTS_PREVIEW_DATA_CY = "ne-attachments-preview-content";

--- a/src/components/Attachments/constants.js
+++ b/src/components/Attachments/constants.js
@@ -10,10 +10,10 @@ export const DEFAULT_FILE_UPLOAD_CONFIG = {
 };
 
 export const ATTACHMENT_OPTIONS = {
-  OPEN_IN_NEW_TAB: "neetoEditor.common.openInNewTab",
-  DOWNLOAD: "neetoEditor.common.download",
-  RENAME: "neetoEditor.attachments.rename",
-  DELETE: "neetoEditor.menu.delete",
+  OPEN_IN_NEW_TAB: t("neetoEditor.common.openInNewTab"),
+  DOWNLOAD: t("neetoEditor.common.download"),
+  RENAME: t("neetoEditor.attachments.rename"),
+  DELETE: t("neetoEditor.menu.delete"),
 };
 
 export const ATTACHMENTS_PREVIEW_DATA_CY = "ne-attachments-preview-content";

--- a/src/components/Attachments/constants.js
+++ b/src/components/Attachments/constants.js
@@ -1,3 +1,4 @@
+import { t } from "i18next";
 import { globalProps } from "neetocommons/initializers";
 
 import { DIRECT_UPLOAD_ENDPOINT } from "src/common/constants";

--- a/src/components/Attachments/index.jsx
+++ b/src/components/Attachments/index.jsx
@@ -36,7 +36,7 @@ const Attachments = (
     config = {},
     setIsUploading = noop,
     allowDelete = true,
-    allowOpenInNewTab = false,
+    allowOpenInNewTab = true,
   },
   ref
 ) => {

--- a/src/components/Attachments/index.jsx
+++ b/src/components/Attachments/index.jsx
@@ -36,6 +36,7 @@ const Attachments = (
     config = {},
     setIsUploading = noop,
     allowDelete = true,
+    allowOpenInNewTab = false,
   },
   ref
 ) => {
@@ -96,6 +97,7 @@ const Attachments = (
           <Attachment
             {...{
               allowDelete,
+              allowOpenInNewTab,
               attachment,
               attachments,
               disabled,

--- a/src/components/Attachments/utils.js
+++ b/src/components/Attachments/utils.js
@@ -6,19 +6,22 @@ import { DEFAULT_FILE_UPLOAD_CONFIG } from "./constants";
 export const buildFileUploadConfig = config =>
   mergeRight(DEFAULT_FILE_UPLOAD_CONFIG, config);
 
-export const downloadFile = (fileUrl, filename) => {
+export const downloadFile = async (fileUrl, filename) => {
   try {
-    const a = document.createElement("a");
-    a.href = fileUrl;
-    a.setAttribute("download", filename);
-    a.setAttribute("target", "_blank");
+    const response = await fetch(fileUrl);
+    const blob = await response.blob();
+    const blobUrl = URL.createObjectURL(blob);
 
+    const a = document.createElement("a");
+    a.href = blobUrl;
+    a.setAttribute("download", filename);
     a.style.display = "none";
     document.body.appendChild(a);
 
     a.click();
 
     document.body.removeChild(a);
+    URL.revokeObjectURL(blobUrl);
   } catch (error) {
     Toastr.error(error);
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -28,7 +28,8 @@
       "nameEmpty": "Filename cannot be empty",
       "noPreview": "There is no preview available, click to <span>download</span>.",
       "oneAttachmentAllowed": "Only one attachment is allowed",
-      "uploading": "Uploading"
+      "uploading": "Uploading",
+      "rename": "Rename"
     },
     "error": {
       "invalidUrl": "Please enter a valid URL.",

--- a/types.d.ts
+++ b/types.d.ts
@@ -153,7 +153,7 @@ interface AttachmentsProps {
 
 type EditorContentConfigType = {
   enableHeaderLinks?: boolean;
-};
+}
 
 export function Editor(props: EditorProps): JSX.Element;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -148,11 +148,12 @@ interface AttachmentsProps {
   className?: string;
   showToastr?: boolean;
   allowDelete?: boolean;
+  allowOpenInNewTab?: boolean;
 }
 
 type EditorContentConfigType = {
   enableHeaderLinks?: boolean;
-}
+};
 
 export function Editor(props: EditorProps): JSX.Element;
 


### PR DESCRIPTION
- Fixes #1716
### Description
Ref: https://github.com/neetozone/neeto-desk-web/issues/23274
### Checklist
- [x] Add `Open attachment in new tab` 
- [x] Clicking on download button should download the image instead of opening it
- [x] Add save icon for renaming image



- [x] I have made corresponding changes to the documentation.
- [x] I have updated the types definition of modified exports.
- [x] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**
