### PR TITLE
Fix showAssetLibrary not reaching MediaUploader in Fixed and Headless menus

### DIFF
--- a/src/components/Editor/Menu/Fixed/index.jsx
+++ b/src/components/Editor/Menu/Fixed/index.jsx
@@ -31,6 +31,7 @@ const Fixed = ({
   openLinkInNewTab,
   setIsNeetoKbArticleActive,
   neetoKbArticleState,
+  showAssetLibrary = true,
 }) => {
   const [focusedButtonIndex, setFocusedButtonIndex] = useState(0);
   const [isAddLinkActive, setIsAddLinkActive] = useState(false);
@@ -178,7 +179,7 @@ const Fixed = ({
       )}
       {isMediaUploaderActive && (
         <MediaUploader
-          {...{ editor, mediaUploader }}
+          {...{ editor, mediaUploader, showAssetLibrary }}
           onClose={() => setMediaUploader({ image: false, video: false })}
         />
       )}

--- a/src/components/Editor/Menu/Headless/index.jsx
+++ b/src/components/Editor/Menu/Headless/index.jsx
@@ -17,6 +17,7 @@ const Headless = ({
   attachmentProps,
   isEmojiPickerActive,
   setIsEmojiPickerActive,
+  showAssetLibrary = true,
 }) => {
   if (!editor) {
     return null;
@@ -49,7 +50,7 @@ const Headless = ({
       ))}
       {isMediaUploaderActive && (
         <MediaUploader
-          {...{ editor, mediaUploader }}
+          {...{ editor, mediaUploader, showAssetLibrary }}
           onClose={() => setMediaUploader({ image: false, video: false })}
         />
       )}

--- a/src/components/Editor/index.jsx
+++ b/src/components/Editor/index.jsx
@@ -280,6 +280,7 @@ const Editor = (
                 menuType,
                 neetoKbArticleState,
                 openLinkInNewTab,
+                showAssetLibrary,
                 tooltips,
                 variables,
               }}


### PR DESCRIPTION
Required for https://github.com/neetozone/neeto-engage-web/issues/1516