### PR TITLE
Fixed Firefox crash when editor is used inside shadow DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "resolutions": {
     "jackspeak": "2.1.1",
-    "prosemirror-view": "1.33.4",
+    "prosemirror-view": "1.33.11",
     "prosemirror-model": "1.22.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13370,10 +13370,10 @@ prosemirror-transform@^1.2.1, prosemirror-transform@^1.7.3, prosemirror-transfor
   dependencies:
     prosemirror-model "^1.21.0"
 
-prosemirror-view@1.33.4, prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.13.3, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.33.9:
-  version "1.33.4"
-  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.33.4.tgz#ff75e7ea3948f1bc00877e4f19150410f9ab5d52"
-  integrity sha512-xQqAhH8/HGleVpKDhQsrd+oqdyeKMxFtdCWDxWMmP+n0k27fBpyUqa8pA+RB5cFY8rqDDc1hll69aRZQa7UaAw==
+prosemirror-view@1.33.11, prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.13.3, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.33.9:
+  version "1.33.11"
+  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.33.11.tgz#15a6d763f33da7e5dfdeaaf392b6c0175831390a"
+  integrity sha512-K0z9oMf6EI2ZifS9yW8PUPjEw2o1ZoFAaNzvcuyfcjIzsU6pJMo3tk9r26MyzEsuGHXZwmKPEmrjgFd78biTGA==
   dependencies:
     prosemirror-model "^1.20.0"
     prosemirror-state "^1.0.0"


### PR DESCRIPTION
- Fixes #1701 

**Description**

The error originates from the prosemirror-view package, which did not handle null being returned from getSelection() in Firefox shadow DOM contexts. This issue was fixed upstream in prosemirror-view@1.33.10. Upgrading from 1.33.4 to 1.33.11 resolves the issue.

**Checklist**

- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated the types definition of modified exports.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [ ] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
